### PR TITLE
fix(non-person) permite login de usuários sem CPF

### DIFF
--- a/src/AuthIdUFFS.php
+++ b/src/AuthIdUFFS.php
@@ -141,9 +141,10 @@ class AuthIdUFFS
             'username' => $data->username,
             'uid' => $data->uid[0],
             'email' => $data->mail[0],
-            'pessoa_id' => $data->pessoa_id[0],
+            'pessoa_id' => count($data->pessoa_id) > 0 ? $data->pessoa_id[0] : '',
             'name' => $data->cn[0],
-            'cpf' => $data->employeeNumber[0],
+            'cpf' => count($data->employeeNumber) > 0 ? $data->employeeNumber[0] : '',
+            'location' => count($data->sn) > 0 ? $data->sn[0] : '',
             'token_id' => $data->token_id,
             'authenticated' => $data->authenticated
         ];


### PR DESCRIPTION
Esse PR corrige um erro quando usuários sem CPF tentam se autenticar. Isso acontece com contas do idUFFS vinculadas a setores, como é o caso das coordenações de curso, ex.  `computacao.ch`.

Como a informação de localização da conta (cidate, campus, etc) é importante para esse tipo de usuário (sem CPF), aproveitei e retornei essa info no campo `location`.

Esse PR não é bem um fix, é um `fix/feature` 😛 

P.S. Já rodei todos os testes localmente, inclusive autenticando com a conta da coordenação e minha, e tudo parece estar ok. Como esse fix impacta o app [grintex/horarios](https://github.com/grintex/horarios) para produção, não vou esperar muito para o review :shipit: 